### PR TITLE
fix: Sheba word in document, convert to shetab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # iran-shetab
+
 A javascript library to validate and recognize Shetab card numbers
 
 Credit & Debit Card (Shetab) validation and Recognition in javascript.
 
-To use iran sheba you just need to:
+To use iran shetab you just need to:
 
-	npm install iran-shetab --save
+    npm install iran-shetab --save
 
 ## Usage
 
 How to use it:
-```js
-var Sheba = require('iran-sheba');
 
-console.log(Sheba.isValid('6221-0611-****-****'));
-console.log(Sheba.isValid('62210611********'));
-console.log(Sheba.isValid('62210611********'));
+```js
+var Shetab = require("iran-shetab");
+
+console.log(Shetab.isValid("6221-0611-****-****"));
+console.log(Shetab.isValid("62210611********"));
+console.log(Shetab.isValid("62210611********"));
 ```
 
 # Suggestions?


### PR DESCRIPTION
I just fix typo mistake in importing `iran-shetab` module in your documentation.